### PR TITLE
Linted metaraine

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
+# 0.1.0 / 2015-01-29
 
-0.0.1 / 2013-04-17
-==================
+  - Browser support
+  - mergeFlagObjects method
+  - Allow cloning of pseudo-RegExp objects
 
-  * initial commit
+# 0.0.1 / 2013-04-17
+
+  - initial commit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-#regexp-clone
-==============
+# regexp-clone
 
 Clones RegExps with flag preservation:
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,39 @@
 #regexp-clone
 ==============
 
-Clones RegExps with flag preservation
+Clones RegExps with flag preservation:
 
 ```js
 var regexpClone = require('regexp-clone');
 
-var a = /somethin/g;
-console.log(a.global); // true
+var a = /somethin/gmi;
 
 var b = regexpClone(a);
 console.log(b.global); // true
+console.log(b.multiline); // true
+console.log(b.ignoreCase); // true
 ```
 
+Override flags:
+
+```js
+var a = /somethin/g;
+var b = regexpClone(a, 'm');
+console.log(b.global); // true
+console.log(b.multiline); // true
+console.log(b.ignoreCase); // false
+```
+
+```js
+var a = /somethin/g;
+var b = regexpClone(a, {
+	'global': false,
+	multiline: true
+});
+console.log(b.global); // false
+console.log(b.multiline); // true
+console.log(b.ignoreCase); // false
+```
 ## License
 
 [MIT](https://github.com/aheckmann/regexp-clone/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,33 @@
 # regexp-clone
 
+## Installation
+
+Node:
+
+```
+npm install regexp-clone
+```
+
+```js
+var cloneRegex = require('regexp-clone');
+```
+
+Browser:
+
+```js
+<script src="regexp-clone/index.js"></script>
+```
+
+## Usage
+
 Clones RegExps with flag preservation:
 
 ```js
-var regexpClone = require('regexp-clone');
+
 
 var a = /somethin/gmi;
 
-var b = regexpClone(a);
+var b = cloneRegex(a);
 console.log(b.global); // true
 console.log(b.multiline); // true
 console.log(b.ignoreCase); // true
@@ -17,7 +37,7 @@ Override flags:
 
 ```js
 var a = /somethin/g;
-var b = regexpClone(a, 'm');
+var b = cloneRegex(a, 'm');
 console.log(b.global); // true
 console.log(b.multiline); // true
 console.log(b.ignoreCase); // false
@@ -25,7 +45,7 @@ console.log(b.ignoreCase); // false
 
 ```js
 var a = /somethin/g;
-var b = regexpClone(a, {
+var b = cloneRegex(a, {
 	'global': false,
 	multiline: true
 });

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ var propertyFlagMap = flags.reduce(function (o, f) {
 
 /**
 * Creates a flag object from a string of flags. Unspecified flags are omitted (not set to false).
+* @param {string} s The string from which to create a flag object
+* @returns {object} The object with boolean RegExp properties
 * @example
     parseFlagString('gm') ->
     {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /*jslint node:true, vars:true*/
 
-var exports;
+var module;
 (function (undef) {'use strict';
 
 
@@ -70,7 +70,7 @@ function toFlagString (flagObject) {
 * @param {RegExp|object|string} newFlags Values for overriding the regex
 * @returns {RegExp} The cloned (and optionally altered) RegExp
 */
-function clone (regex, newFlags) {
+function cloneRegex (regex, newFlags) {
 
   newFlags = newFlags || {};
 
@@ -80,9 +80,15 @@ function clone (regex, newFlags) {
   return new RegExp(regex.source, mergedFlagString);
 }
 
-module.exports = exports = clone;
-exports.parseFlagString = parseFlagString;
-exports.mergeFlagObjects = mergeFlagObjects;
-exports.toFlagString = toFlagString;
+cloneRegex.parseFlagString = parseFlagString;
+cloneRegex.mergeFlagObjects = mergeFlagObjects;
+cloneRegex.toFlagString = toFlagString;
+
+if (module === undef) {
+    window.cloneRegex = cloneRegex;
+}
+else {
+    module.exports = cloneRegex;
+}
 
 }());

--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
   "license": "MIT",
   "devDependencies": {
     "mocha": "1.8.1"
+  },
+  "dependencies": {
+    "cint": "^8.0.1",
+    "lodash": "^2.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regexp-clone",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Clone RegExps with options",
   "main": "index.js",
   "scripts": {
@@ -15,12 +15,9 @@
     "clone"
   ],
   "author": "Aaron Heckmann <aaron.heckmann+github@gmail.com>",
+  "contributors": [{"name": "Brett Zamir"}, {"name": "metaraine"}],
   "license": "MIT",
   "devDependencies": {
     "mocha": "1.8.1"
-  },
-  "dependencies": {
-    "cint": "^8.0.1",
-    "lodash": "^2.4.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -73,6 +73,45 @@ describe('regexp-clone', function(){
       multilineFlag(a);
       done();
     })
+    it('should add flags provided as a string', function(done) {
+      var a = /hello/g;
+      var b = clone(a, 'mi');
+      assert.ok(b.global);
+      assert.ok(b.multiline);
+      assert.ok(b.ignoreCase);
+      done();
+    })
+    it('should add flags from an object', function(done) {
+      var a = /hello/g;
+      var b = clone(a, {
+        multiline: true,
+        ignoreCase: true
+      });
+      assert.ok(b.global);
+      assert.ok(b.multiline);
+      assert.ok(b.ignoreCase);
+      done();
+    })
+    it('should preserve flags that are missing in a given override object', function(done) {
+      var a = /hello/g;
+      var b = clone(a, {});
+      assert.ok(b.global);
+      assert.ok(!b.multiline);
+      assert.ok(!b.ignoreCase);
+      done();
+    })
+    it('should override true flags', function(done) {
+      var a = /hello/g;
+      var b = clone(a, {
+        'global': false,
+        multiline: true,
+        ignoreCase: true
+      });
+      assert.ok(!b.global);
+      assert.ok(b.multiline);
+      assert.ok(b.ignoreCase);
+      done();
+    })
   })
 
   describe('instances', function(){
@@ -105,6 +144,27 @@ describe('regexp-clone', function(){
       insensitiveFlag(a);
       globalFlag(a);
       multilineFlag(a);
+      done();
+    })
+  })
+
+  describe('toFlagString', function() {
+    it('should convert a flag object to a string of flag characters', function(done) {
+      assert.deepEqual(clone.toFlagString({
+        'global': true,
+        'ignoreCase': false
+      }), 'g')
+      done();
+    })
+  })
+
+  describe('parseFlagString', function() {
+    it('should convert a string of flag characters to a flag object', function(done) {
+      assert.deepEqual(clone.parseFlagString('gmi'), {
+        'global': true,
+        'multiline': true,
+        'ignoreCase': true
+      })
       done();
     })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert')
-var clone = require('../');
+var cloneRegex = require('../');
 
 describe('regexp-clone', function(){
   function hasEqualSource (a, b) {
@@ -21,21 +21,21 @@ describe('regexp-clone', function(){
   }
 
   function insensitiveFlag (a) {
-    var b = clone(a);
+    var b = cloneRegex(a);
     hasEqualSource(a, b);
     isInsensitive(a);
     isInsensitive(b);
   }
 
   function globalFlag (a) {
-    var b = clone(a);
+    var b = cloneRegex(a);
     hasEqualSource(a, b);
     isGlobal(a);
     isGlobal(b);
   }
 
   function multilineFlag (a) {
-    var b = clone(a);
+    var b = cloneRegex(a);
     hasEqualSource(a, b);
     isMultiline(a);
     isMultiline(b);
@@ -59,7 +59,7 @@ describe('regexp-clone', function(){
     })
     it('no flags', function(done){
       var a = /hello/;
-      var b = clone(a);
+      var b = cloneRegex(a);
       hasEqualSource(a, b);
       assert.ok(!a.insensitive);
       assert.ok(!a.global);
@@ -75,7 +75,7 @@ describe('regexp-clone', function(){
     })
     it('should add flags provided as a string', function(done) {
       var a = /hello/g;
-      var b = clone(a, 'mi');
+      var b = cloneRegex(a, 'mi');
       assert.ok(b.global);
       assert.ok(b.multiline);
       assert.ok(b.ignoreCase);
@@ -83,7 +83,7 @@ describe('regexp-clone', function(){
     })
     it('should add flags from an object', function(done) {
       var a = /hello/g;
-      var b = clone(a, {
+      var b = cloneRegex(a, {
         multiline: true,
         ignoreCase: true
       });
@@ -94,7 +94,7 @@ describe('regexp-clone', function(){
     })
     it('should preserve flags that are missing in a given override object', function(done) {
       var a = /hello/g;
-      var b = clone(a, {});
+      var b = cloneRegex(a, {});
       assert.ok(b.global);
       assert.ok(!b.multiline);
       assert.ok(!b.ignoreCase);
@@ -102,7 +102,7 @@ describe('regexp-clone', function(){
     })
     it('should override true flags', function(done) {
       var a = /hello/g;
-      var b = clone(a, {
+      var b = cloneRegex(a, {
         'global': false,
         multiline: true,
         ignoreCase: true
@@ -132,7 +132,7 @@ describe('regexp-clone', function(){
     })
     it('no flags', function(done){
       var a = new RegExp('hmm');
-      var b = clone(a);
+      var b = cloneRegex(a);
       hasEqualSource(a, b);
       assert.ok(!a.insensitive);
       assert.ok(!a.global);
@@ -150,7 +150,7 @@ describe('regexp-clone', function(){
 
   describe('toFlagString', function() {
     it('should convert a flag object to a string of flag characters', function(done) {
-      assert.deepEqual(clone.toFlagString({
+      assert.deepEqual(cloneRegex.toFlagString({
         'global': true,
         'ignoreCase': false
       }), 'g')
@@ -160,7 +160,7 @@ describe('regexp-clone', function(){
 
   describe('parseFlagString', function() {
     it('should convert a string of flag characters to a flag object', function(done) {
-      assert.deepEqual(clone.parseFlagString('gmi'), {
+      assert.deepEqual(cloneRegex.parseFlagString('gmi'), {
         'global': true,
         'multiline': true,
         'ignoreCase': true


### PR DESCRIPTION
Adapts @metaraine's code to add JSLint and JSDoc; removes cint and lodash dependencies (for simplification and providing capacity for out-of-the-box browser support without a build step); exports a new mergeFlagObjects method; allows cloning of pseudo-RegExp objects.
