### PR TITLE
feat: support sticky, unicode and dotAll

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,13 @@ module.exports = exports = function (regexp) {
   if (regexp.global) flags.push('g');
   if (regexp.multiline) flags.push('m');
   if (regexp.ignoreCase) flags.push('i');
-  return new RegExp(regexp.source, flags.join(''));
+  if (regexp.dotAll) flags.push('s');
+  if (regexp.unicode) flags.push('u');
+  if (regexp.sticky) flags.push('y');
+  var result = new RegExp(regexp.source, flags.join(''));
+  if (typeof regexp.lastIndex === 'number') {
+    result.lastIndex = regexp.lastIndex;
+  }
+  return result;
 }
 


### PR DESCRIPTION
Close #3.
Especially dotAll (`s` flag) to provide [mongodb $regex support](https://docs.mongodb.com/manual/reference/operator/query/regex/) for mongoose

If this PR is accepted, please release a new version in order to use it in mongoose.